### PR TITLE
Update utils.py

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -28,7 +28,7 @@ class MDIterator:
 
         try:
             return self.trajectory[self.index]
-        except IndexError, ex:
+        except IndexError as ex:
             raise StopIteration
 
 


### PR DESCRIPTION
Fixed 'except IndexError, ex' syntax for Python2/3 compatibility.